### PR TITLE
Fixes #80 - moved theme-switching logic to a separate component

### DIFF
--- a/src/app/@core/auth/login/login.component.ts
+++ b/src/app/@core/auth/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { AuthService } from '../../services/auth.service';
 import { Router } from '@angular/router';
+import { ThemeSwitcherComponent } from '../../../@theme/components/header/theme-switcher/theme-switcher.component';
 
 @Component({
   templateUrl: './login.component.html',
@@ -37,11 +38,8 @@ export class LoginComponent {
   isDarkTheme: boolean;
 
   constructor(private authService: AuthService, private router: Router) {
-    this.isDarkTheme = LoginComponent.getThemeName() === 'dark' ? true : false;
-  }
-
-  static getThemeName(): string {
-    return localStorage.getItem('themeName') || 'dark';
+    this.isDarkTheme =
+      ThemeSwitcherComponent.getThemeName() === 'dark' ? true : false;
   }
 
   async login() {

--- a/src/app/@theme/components/header/header.component.html
+++ b/src/app/@theme/components/header/header.component.html
@@ -21,15 +21,7 @@
 <div class="header-container">
   <nb-actions size="small">
     <!-- Theme Switcher -->
-    <nb-action class="d-flex align-items-center">
-      <nb-icon icon="sun-outline" size="tiny"></nb-icon>
-      <nb-toggle
-        class="mx-2"
-        (checkedChange)="changeTheme($event)"
-        [(checked)]="isDarkTheme"
-      ></nb-toggle>
-      <nb-icon icon="moon-outline" size="tiny"></nb-icon>
-    </nb-action>
+    <theme-switcher></theme-switcher>
     <!-- User actions -->
     <nb-action class="user-action" *ngIf="userService.user$ | async as user">
       <nb-user

--- a/src/app/@theme/components/header/header.component.ts
+++ b/src/app/@theme/components/header/header.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { NbMenuItem, NbMenuService, NbSidebarService } from '@nebular/theme';
 import { UserService } from '../../../@core/services/user.service';
 import { filter, map, take } from 'rxjs/operators';
+import { ThemeSwitcherComponent } from './theme-switcher/theme-switcher.component';
 
 @Component({
   selector: 'ngx-header',
@@ -21,7 +22,8 @@ export class HeaderComponent implements OnInit {
     private nbMenuService: NbMenuService,
     public userService: UserService
   ) {
-    this.isDarkTheme = HeaderComponent.getThemeName() === 'dark' ? true : false;
+    this.isDarkTheme =
+      ThemeSwitcherComponent.getThemeName() === 'dark' ? true : false;
   }
 
   ngOnInit(): void {
@@ -57,9 +59,5 @@ export class HeaderComponent implements OnInit {
   navigateHome(): boolean {
     this.nbMenuService.navigateHome();
     return false;
-  }
-
-  static getThemeName(): string {
-    return localStorage.getItem('themeName') || 'dark';
   }
 }

--- a/src/app/@theme/components/header/header.component.ts
+++ b/src/app/@theme/components/header/header.component.ts
@@ -1,10 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import {
-  NbMenuItem,
-  NbMenuService,
-  NbSidebarService,
-  NbThemeService,
-} from '@nebular/theme';
+import { NbMenuItem, NbMenuService, NbSidebarService } from '@nebular/theme';
 import { UserService } from '../../../@core/services/user.service';
 import { filter, map, take } from 'rxjs/operators';
 
@@ -18,16 +13,12 @@ export class HeaderComponent implements OnInit {
     { title: 'Django Admin Interface' },
     { title: 'Log out' },
   ];
-  isDarkTheme: boolean;
 
   constructor(
     private sidebarService: NbSidebarService,
     private nbMenuService: NbMenuService,
-    public userService: UserService,
-    private themeService: NbThemeService
-  ) {
-    this.isDarkTheme = HeaderComponent.getThemeName() === 'dark' ? true : false;
-  }
+    public userService: UserService
+  ) {}
 
   ngOnInit(): void {
     this.nbMenuService
@@ -54,13 +45,6 @@ export class HeaderComponent implements OnInit {
       });
   }
 
-  changeTheme(toggleFlag: boolean): void {
-    let themeName: string;
-    toggleFlag ? (themeName = 'dark') : (themeName = 'default');
-    localStorage.setItem('themeName', themeName);
-    this.themeService.changeTheme(themeName);
-  }
-
   toggleSidebar(): boolean {
     this.sidebarService.toggle(true, 'menu-sidebar');
     return false;
@@ -69,9 +53,5 @@ export class HeaderComponent implements OnInit {
   navigateHome(): boolean {
     this.nbMenuService.navigateHome();
     return false;
-  }
-
-  static getThemeName(): string {
-    return localStorage.getItem('themeName') || 'dark';
   }
 }

--- a/src/app/@theme/components/header/header.component.ts
+++ b/src/app/@theme/components/header/header.component.ts
@@ -9,6 +9,8 @@ import { filter, map, take } from 'rxjs/operators';
   templateUrl: './header.component.html',
 })
 export class HeaderComponent implements OnInit {
+  isDarkTheme: boolean;
+
   userMenu: NbMenuItem[] = [
     { title: 'Django Admin Interface' },
     { title: 'Log out' },
@@ -18,7 +20,9 @@ export class HeaderComponent implements OnInit {
     private sidebarService: NbSidebarService,
     private nbMenuService: NbMenuService,
     public userService: UserService
-  ) {}
+  ) {
+    this.isDarkTheme = HeaderComponent.getThemeName() === 'dark' ? true : false;
+  }
 
   ngOnInit(): void {
     this.nbMenuService
@@ -53,5 +57,9 @@ export class HeaderComponent implements OnInit {
   navigateHome(): boolean {
     this.nbMenuService.navigateHome();
     return false;
+  }
+
+  static getThemeName(): string {
+    return localStorage.getItem('themeName') || 'dark';
   }
 }

--- a/src/app/@theme/components/header/theme-switcher/theme-switcher.component.html
+++ b/src/app/@theme/components/header/theme-switcher/theme-switcher.component.html
@@ -1,0 +1,9 @@
+<nb-action class="d-flex align-items-center">
+  <nb-icon icon="sun-outline" size="tiny"></nb-icon>
+  <nb-toggle
+    class="mx-2"
+    (checkedChange)="changeTheme($event)"
+    [(checked)]="isDarkTheme"
+  ></nb-toggle>
+  <nb-icon icon="moon-outline" size="tiny"></nb-icon>
+</nb-action>

--- a/src/app/@theme/components/header/theme-switcher/theme-switcher.component.ts
+++ b/src/app/@theme/components/header/theme-switcher/theme-switcher.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { NbThemeService } from '@nebular/theme';
+
+@Component({
+  selector: 'theme-switcher',
+  templateUrl: './theme-switcher.component.html',
+  styleUrls: ['./theme-switcher.component.scss'],
+})
+export class ThemeSwitcherComponent {
+  isDarkTheme: boolean;
+
+  constructor(private themeService: NbThemeService) {
+    this.isDarkTheme =
+      ThemeSwitcherComponent.getThemeName() === 'dark' ? true : false;
+  }
+
+  changeTheme(toggleFlag: boolean): void {
+    let themeName: string;
+    toggleFlag ? (themeName = 'dark') : (themeName = 'default');
+    localStorage.setItem('themeName', themeName);
+    this.themeService.changeTheme(themeName);
+  }
+
+  static getThemeName(): string {
+    return localStorage.getItem('themeName') || 'dark';
+  }
+}

--- a/src/app/@theme/theme.module.ts
+++ b/src/app/@theme/theme.module.ts
@@ -18,7 +18,7 @@ import {
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { ImageVisualizerComponent } from './components/image-visualizer/image-visualizer.component';
-
+import { ThemeSwitcherComponent } from './components/header/theme-switcher/theme-switcher.component';
 import { CapitalizePipe, TimingPipe, NumberWithCommasPipe } from './pipes';
 import {
   OneColumnLayoutComponent,
@@ -50,6 +50,7 @@ const COMPONENTS = [
   OneColumnLayoutComponent,
   ThreeColumnsLayoutComponent,
   TwoColumnsLayoutComponent,
+  ThemeSwitcherComponent,
 ];
 
 const PIPES = [CapitalizePipe, TimingPipe, NumberWithCommasPipe];
@@ -71,7 +72,7 @@ export class ThemeModule {
       providers: [
         ...NbThemeModule.forRoot(
           {
-            name: HeaderComponent.getThemeName(),
+            name: ThemeSwitcherComponent.getThemeName(),
           },
           [DEFAULT_THEME, DARK_THEME]
         ).providers,


### PR DESCRIPTION
Fixes #80 
- [x] Create separate component inside `header`
- [x] Move theme switching logic to new component
- [ ] Use new component inside `header`
- [ ] Squash commits