### PR TITLE
Fixes #120: Prevent running unsupported/duplicate analyzers by clearing `select` list on observable type change

### DIFF
--- a/src/app/pages/scans/scans-management/scan-observable/scan-observable.component.ts
+++ b/src/app/pages/scans/scans-management/scan-observable/scan-observable.component.ts
@@ -25,7 +25,9 @@ export class ScanObservableComponent {
   }
 
   onObsClassificationChange(): void {
+    // Clear selected analyzers on classification change
     this.formData.analyzers_requested = [];
+
     switch (this.formData.classification) {
       case 'ip':
         this.obsPlaceholder = '8.8.8.8';

--- a/src/app/pages/scans/scans-management/scan-observable/scan-observable.component.ts
+++ b/src/app/pages/scans/scans-management/scan-observable/scan-observable.component.ts
@@ -25,6 +25,7 @@ export class ScanObservableComponent {
   }
 
   onObsClassificationChange(): void {
+    this.formData.analyzers_requested = [];
     switch (this.formData.classification) {
       case 'ip':
         this.obsPlaceholder = '8.8.8.8';


### PR DESCRIPTION
1. Select analyzers in `ip` classification, for example.
2. Switch to `url`
3. Old behavior: Selected analyzers remain as it is, allowing user to run unsupported/duplicated analyzers.
    Now: Previously selected analyzers are cleared out.
