### PR TITLE
Fixes #94: Add report metrics, fix report sorting

### DIFF
--- a/src/app/pages/dashboard/job-result/job-result.component.html
+++ b/src/app/pages/dashboard/job-result/job-result.component.html
@@ -28,11 +28,7 @@
                 class="d-flex justify-content-between"
               >
                 <span>Analyzer Reports</span>
-                <span
-                  >completed: {{ jobObj?.analyzer_reports.length }}/{{
-                    jobObj?.analyzers_to_execute.length
-                  }}</span
-                >
+                <span>{{ generateReportTableMetrics('analyzer') }}</span>
               </nb-card-header>
               <nb-card-body>
                 <ng2-smart-table
@@ -60,11 +56,7 @@
                 class="d-flex justify-content-between"
               >
                 <span>Connector Reports</span>
-                <span
-                  >completed: {{ jobObj?.connector_reports.length }}/{{
-                    jobObj?.connectors_to_execute.length
-                  }}</span
-                >
+                <span>{{ generateReportTableMetrics('connector') }}</span>
               </nb-card-header>
               <nb-card-body>
                 <ng2-smart-table

--- a/src/app/pages/dashboard/job-result/job-result.component.ts
+++ b/src/app/pages/dashboard/job-result/job-result.component.ts
@@ -57,7 +57,9 @@ export class JobResultComponent implements OnInit, OnDestroy {
         type: 'custom',
         filter: false,
         width: '3%',
-        compareFunction: (direction, a, b) => (a === b ? 1 : -1 * direction),
+        // sort: false,
+        // compareFunction: (direction, a, b) => (a === b ? 1 : -1 * direction),
+        compareFunction: this.compareReportStatus,
         renderComponent: JobStatusIconRenderComponent,
       },
       process_time: {
@@ -104,6 +106,14 @@ export class JobResultComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    // set sorting for data sources
+    const sortingConf = [
+      { field: 'name', direction: 'asc' }, // secondary sort
+      { field: 'status', direction: 'asc', compare: this.compareReportStatus }, // primary sort
+    ];
+    this.analyzerTableDataSource.setSort(sortingConf);
+    this.connectorTableDataSource.setSort(sortingConf);
+
     // subscribe to jobResult
     this.jobService
       .pollForJob(this.jobId)
@@ -140,6 +150,20 @@ export class JobResultComponent implements OnInit, OnDestroy {
     );
   }
 
+  private compareReportStatus(direction: number, a: string, b: string) {
+    a = a.toLowerCase();
+    b = b.toLowerCase();
+    const priority = {
+      success: 0,
+      failed: 1,
+      killed: 2,
+      running: 3,
+      pending: 4,
+    };
+
+    return priority[a] < priority[b] ? -1 * direction : direction;
+  }
+
   private updateJobData(res: Job): void {
     // load data into the analysis table data source
     this.analyzerTableDataSource.load(res.analyzer_reports);
@@ -169,6 +193,28 @@ export class JobResultComponent implements OnInit, OnDestroy {
       return 'Connectors will be triggered when job analysis finishes without fails.';
     else if (['failed', 'reported_with_fails', 'killed'].includes(jobStatus))
       return 'No connectors were triggered because job analysis failed or was killed';
+  }
+
+  generateReportTableMetrics(pluginType: string) {
+    let pluginReports: any[],
+      numpluginsToExecute: number,
+      running = 0,
+      completed = 0;
+    if (pluginType === 'analyzer') {
+      pluginReports = this.jobObj.analyzer_reports;
+      numpluginsToExecute = this.jobObj.analyzers_to_execute.length;
+    } else {
+      pluginReports = this.jobObj.connector_reports;
+      numpluginsToExecute = this.jobObj.connectors_to_execute.length;
+    }
+    for (const report of pluginReports) {
+      const status = report.status.toLowerCase();
+      if (status === 'running') running++;
+      else if (status !== 'pending') completed++;
+    }
+    return `Started: ${pluginReports.length}/${numpluginsToExecute}, ${
+      running > 0 ? `Running: ${running}/${numpluginsToExecute},` : ``
+    } Completed: ${completed}/${numpluginsToExecute}`;
   }
 
   // event emitted when user clicks on a row in table

--- a/src/app/pages/dashboard/job-result/job-result.component.ts
+++ b/src/app/pages/dashboard/job-result/job-result.component.ts
@@ -57,8 +57,6 @@ export class JobResultComponent implements OnInit, OnDestroy {
         type: 'custom',
         filter: false,
         width: '3%',
-        // sort: false,
-        // compareFunction: (direction, a, b) => (a === b ? 1 : -1 * direction),
         compareFunction: this.compareReportStatus,
         renderComponent: JobStatusIconRenderComponent,
       },

--- a/src/app/pages/pages.component.ts
+++ b/src/app/pages/pages.component.ts
@@ -36,6 +36,15 @@ export class PagesComponent {
       link: '/pages/analyzers/tree',
     },
     {
+      title: 'Connectors Management',
+      group: true,
+    },
+    {
+      title: 'Table View',
+      icon: 'list-outline',
+      link: '/pages/connectors',
+    },
+    {
       title: 'Scans Management',
       group: true,
     },
@@ -48,15 +57,6 @@ export class PagesComponent {
       title: 'Scan a File',
       icon: 'file-add-outline',
       link: '/pages/scan/file',
-    },
-    {
-      title: 'Connectors Management',
-      group: true,
-    },
-    {
-      title: 'Connectors',
-      icon: 'question-mark-circle-outline',
-      link: '/pages/connectors',
     },
   ];
 }


### PR DESCRIPTION
- [x] #94 

Adds metrics for reports of the form: `Started: 10/12, Running: 3/12, Completed: 7/12`
Now the sorting priority for `status` is `success > failed > killed > running > pending`
Sorting: `status` (primary), `name` (`asc`, secondary)

![image](https://user-images.githubusercontent.com/51958314/128466909-11c16e06-1403-4b06-8e72-a1075d3d89af.png)


- [x] #128 
![image](https://user-images.githubusercontent.com/51958314/128466990-cf76154f-3971-40b9-8a2b-3644546922d6.png)
